### PR TITLE
updates for dockerd-rootless-setuptool.sh

### DIFF
--- a/roles/host/defaults/main.yml
+++ b/roles/host/defaults/main.yml
@@ -15,3 +15,6 @@ docker_rootless_capabilities:
 docker_rootless_systemd_delegate_conf: |
   [Service]
   Delegate=cpu cpuset io memory pids
+
+# This must be “true” with Debian 11
+docker_rootless_modprobe_iptables: false

--- a/roles/host/tasks/setup.yml
+++ b/roles/host/tasks/setup.yml
@@ -18,3 +18,9 @@
     - Update grub
     - Reboot host
   when: docker_rootless_cgroupv2
+
+- name: Make sure ip_tables module is present for dockerd-rootless-setuptool.sh
+  community.general.modprobe:
+    name: ip_tables
+    state: present
+    persistent: present

--- a/roles/host/tasks/setup.yml
+++ b/roles/host/tasks/setup.yml
@@ -24,3 +24,4 @@
     name: ip_tables
     state: present
     persistent: present
+  when: docker_rootless_modprobe_iptables

--- a/roles/user/defaults/main.yml
+++ b/roles/user/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Options for the 'dockerd-rootless-setuptool.sh' command
+docker_rootless_setuptool_options: "install"

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: "Run dockerd-rootless-setuptool.sh"
-  ansible.builtin.command: dockerd-rootless-setuptool.sh install
+  ansible.builtin.command: dockerd-rootless-setuptool.sh {{ docker_rootless_setuptool_options }}
   changed_when: false


### PR DESCRIPTION
- add task to make sure ip_tables module is present for dockerd-rootless-setuptool.sh
- add 'docker_rootless_setuptool_options' to pass command arguments easily