### PR TITLE
Capabilities

### DIFF
--- a/roles/host/defaults/main.yml
+++ b/roles/host/defaults/main.yml
@@ -12,8 +12,13 @@ docker_rootless_reboot: false
 
 # capabilities on rootlesskit
 docker_rootless_capabilities:
-  - cap_net_bind_service=ep # Exposing privileged ports
-  - cap_sys_resource=ep # Limiting resources
+  # Exposing privileged ports
+  - cap: cap_net_bind_service=ep
+    state: present
+
+  # Limiting resources
+  - cap: cap_sys_resource=ep
+    state: present
 
 # Limiting resources with systemd as Cgroup Driver
 # https://docs.docker.com/engine/security/rootless/#limiting-resources

--- a/roles/host/tasks/rootless.yml
+++ b/roles/host/tasks/rootless.yml
@@ -84,8 +84,8 @@
 - name: "Rootless : set capabilities on rootlesskit"
   community.general.capabilities:
     path: /usr/bin/rootlesskit
-    capability: "{{ item }}"
-    state: present
+    capability: "{{ item.cap }}"
+    state: "{{ item.state | default('present') }}"
   with_items: "{{ docker_rootless_capabilities }}"
   notify: Restart rootless docker
 


### PR DESCRIPTION
[BREAKING]: Update “docker_rootless_capabilities” fror a list to a list of dict, to manage the capability states.